### PR TITLE
Make the save button redirect to the paste link

### DIFF
--- a/pbnh/app/templates/index.html
+++ b/pbnh/app/templates/index.html
@@ -5,7 +5,7 @@ saveicon.addEventListener('click', function () {
     var xhttp = new XMLHttpRequest();
     xhttp.onreadystatechange = function() {
         if (xhttp.readyState == 4 && xhttp.status == 201 && xhttp.responseText.length) {
-            window.location.href = JSON.parse(xhttp.responseText).id;
+            window.location.href = JSON.parse(xhttp.responseText).link;
         }
     };
     var myForm = new FormData();


### PR DESCRIPTION
Instead of having the save button on the home page independently decide where to redirect after paste creation, this makes it use the returned link. That allows us to control the canonical paste link in one place (`post_paste`)