### PR TITLE
Speed up Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,9 @@ FROM python:3.6-slim
 
 MAINTAINER Bryce Handerson
 
-COPY . /src
-
-# We should find a way to work around this at some point because it makes
-# everything super slow
 RUN apt update && apt install -y python3-dev libmagic-dev
+
+COPY . /src
 RUN pip install /src
 
 ENTRYPOINT ["gunicorn", "--bind", "0.0.0.0:5000", "pbnh.run:app"]


### PR DESCRIPTION
If we `apt install` _after_ `COPY`, we're going to end up re-installing the same thing whenever we build.
If we do it before, then the resulting image will be cached, and the `COPY` will run on top of the cached image.
(Note: I haven't actually _used_ the Dockerfile. I just spotted the comment and knew the fix.)
