### PR TITLE
Disable lookup by ID

### DIFF
--- a/pbnh/app/util.py
+++ b/pbnh/app/util.py
@@ -67,10 +67,10 @@ def getPaste(paste_id):
                       port=str(config.get('port')),
                       username=config.get('username')) as pstr:
         try:
-            return pstr.query(id=paste_id)
+            return pstr.query(hashid=paste_id)
         except ValueError:
             try:
-                return pstr.query(hashid=paste_id)
+                return pstr.query(id=paste_id)
             except ValueError:
                 return None
     return None

--- a/pbnh/app/util.py
+++ b/pbnh/app/util.py
@@ -69,8 +69,5 @@ def getPaste(paste_id):
         try:
             return pstr.query(hashid=paste_id)
         except ValueError:
-            try:
-                return pstr.query(id=paste_id)
-            except ValueError:
-                return None
+            return None
     return None


### PR DESCRIPTION
As promised in #35, this disables fetching pastes by their ID (instead of by their `hashid`).